### PR TITLE
Show boundaries only on hover

### DIFF
--- a/news/boundary.rst
+++ b/news/boundary.rst
@@ -1,0 +1,4 @@
+**Changed:**
+
+* Only display flow component boundary when the surface is hovered. Before,
+  cylinders looked slightly too small in static pictures.

--- a/src/components/FlowComponent.vue
+++ b/src/components/FlowComponent.vue
@@ -313,7 +313,7 @@ export default class FlowComponent extends Vue {
 
 .FlowComponent .boundary {
   stroke: white;
-  opacity: 1;
+  opacity: var(--flat-triangulation-hover, 0);
   stroke-width: 2px;
 }
 </style>


### PR DESCRIPTION
fine tunes display of static pictures.