### PR TITLE
Fix labels on vertical cylinder perimeter

### DIFF
--- a/news/relabel-perimeter.rst
+++ b/news/relabel-perimeter.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Make sure that vertical cylinder perimeters are completely labeled.

--- a/src/components/Surface.vue
+++ b/src/components/Surface.vue
@@ -114,7 +114,8 @@ export default class Surface extends Vue {
 
       // Recompute labels
       let nextLabel = "A";
-      const cylinderInnerHalfEdges = [...this.visibleComponents.filter((component) => component.cylinder).map((component) => component.perimeter.filter((connection) => !connection.vertical && connection.connection.source === -connection.connection.target && connection.connection.crossings.length === 0).map((connection) => connection.connection.source)).flat(), ...this.visibleComponents.map((component) => component.inside).flat()];
+      const componentInnerHalfEdges = [...this.visibleComponents.filter((component) => component.cylinder).map((component) => component.inside)];
+      const cylinderInnerHalfEdges = componentInnerHalfEdges.map((halfEdges) => halfEdges.filter((halfEdge) => halfEdges.includes(-halfEdge))).flat();
 
       this.defaultLabel = {};
       for (const halfEdge of this.surface.halfEdges) {


### PR DESCRIPTION
Before, the `I` label had been missing in this picture:
![image](https://user-images.githubusercontent.com/373765/129012402-bc9b6ec8-af95-4331-9457-d1e8786fe30d.png)
